### PR TITLE
Fix: Update unorderedEqual function to accept string arrays instead o…

### DIFF
--- a/src/app/(Main)/EDT/ui/schedule-form.tsx
+++ b/src/app/(Main)/EDT/ui/schedule-form.tsx
@@ -152,7 +152,7 @@ export default function ScheduleForm({isFormOpen, setIsFormOpenAction}: Schedule
         }
     }, [watchedDate, watchedStartTime, watchedEndTime, form, watchedGroupIds])
 
-    function unorderedEqual(a: number[], b: number[]) {
+    function unorderedEqual(a: string[], b: string[]) {
         return a.length === b.length &&
             a.every(val => b.includes(val)) &&
             b.every(val => a.includes(val));


### PR DESCRIPTION
This pull request includes a minor update to the `ScheduleForm` component to improve type consistency. The `unorderedEqual` function now compares arrays of strings instead of arrays of numbers.