### PR TITLE
ISO 8601 Date 

### DIFF
--- a/src/api/http/level.ts
+++ b/src/api/http/level.ts
@@ -6,11 +6,7 @@ import { IGroup, ILevelDetails } from "@/api/types";
 
 export async function fetchLevels (): Promise<ILevelDetails[]> {
     const {data: responseData} = await http.pub.get("/levels");
-    try {
-        return DTO.LevelDetailsSchema.array().parse(responseData);
-    } catch (e) {
-        throw e;
-    }
+    return DTO.LevelDetailsSchema.array().parse(responseData);
 }
 
 export async function fetchGroupList (levelId: number): Promise<IGroup[]> {

--- a/src/api/http/schedule-item.ts
+++ b/src/api/http/schedule-item.ts
@@ -2,8 +2,11 @@ import { ICreateScheduleItem, IScheduleItem } from "@/api/types";
 import { http } from "@/api/http/axios";
 import { DTO } from "@/api/schemas";
 
+// Earliest supported schedule date. Used as a default to fetch all items if no start date is provided.
+const DEFAULT_SCHEDULE_START_DATE = new Date(1997, 1, 1, 0, 0, 0, 0);
+
 export async function fetchScheduleItemsForLevel (
-    start: Date = new Date(1997, 1, 1, 0, 0, 0, 0),
+    start: Date = DEFAULT_SCHEDULE_START_DATE,
     end: Date = new Date(),
     levelId?: number,
 ): Promise<IScheduleItem[]> {

--- a/src/services/ScheduleItem/impl/real.ts
+++ b/src/services/ScheduleItem/impl/real.ts
@@ -21,7 +21,7 @@ export async function addScheduleItemService (scheduleItem: ScheduleItemPost): P
     const requestBody: ICreateScheduleItem = {
         startTime: scheduleItem.startTime,
         endTime: scheduleItem.endTime,
-        groupIds: scheduleItem.GroupIds.map(s => parseInt(s)),
+        groupIds: scheduleItem.GroupIds.map(s => parseInt(s,10)),
         teacherId: scheduleItem.TeacherId,
         teachingUnitId: scheduleItem.TeachingUnitID,
         roomId: scheduleItem.RoomId


### PR DESCRIPTION
This pull request updates the way date and time values are formatted for schedule items. Instead of truncating the ISO string to remove seconds and timezone information, the code now uses the full ISO string representation for both serialization and API requests. This ensures consistency across the application and avoids potential issues with date/time parsing.

**Date & Time Formatting Improvements:**

* Updated `startTime` and `endTime` preprocessing in `ScheduleItemPostSchema` to use the full ISO string instead of truncating to 19 characters. (`src/Types/ScheduleItem.ts`)
* Changed API request parameters in `fetchScheduleItemsForLevel` to use the complete ISO string for `startDate` and `endDate`. (`src/api/http/schedule-item.ts`)