### PR TITLE
Implement schedule item update and delete service functions

### DIFF
--- a/src/api/http/schedule-item.ts
+++ b/src/api/http/schedule-item.ts
@@ -1,4 +1,4 @@
-import { ICreateScheduleItem, IScheduleItem } from "@/api/types";
+import { ICreateScheduleItem, IScheduleItem, IUpdateScheduleItem } from "@/api/types";
 import { http } from "@/api/http/axios";
 import { DTO } from "@/api/schemas";
 
@@ -20,4 +20,13 @@ export async function fetchScheduleItemsForLevel (
 export async function createScheduleItem (data: ICreateScheduleItem): Promise<IScheduleItem> {
     const {data: responseData} = await http.pub.post(`/schedule`, data);
     return DTO.ScheduleItemSchema.parse(responseData);
+}
+
+export async function updateScheduleItem (scheduleItemId: number, data: IUpdateScheduleItem): Promise<IScheduleItem> {
+    const {data: responseData} = await http.pub.put(`/schedule/${scheduleItemId}`, data);
+    return DTO.ScheduleItemSchema.parse(responseData);
+}
+
+export async function deleteScheduleItem (scheduleItemId: number) {
+    await http.pub.delete(`/schedule/${scheduleItemId}`);
 }

--- a/src/api/schemas/schedule-item.ts
+++ b/src/api/schemas/schedule-item.ts
@@ -22,3 +22,12 @@ export const CreateScheduleItemSchema = z.object({
     startTime: z.string().datetime(),
     endTime: z.string().datetime(),
 });
+
+export const UpdateScheduleItemSchema = z.object({
+    groupIds: z.number().array(),
+    teacherId: z.number(),
+    teachingUnitId: z.number(),
+    roomId: z.number(),
+    startTime: z.string().datetime(),
+    endTime: z.string().datetime(),
+});

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { GroupSchema, LevelDetailsSchema } from "./schemas/group";
 import { RoomSchema } from "./schemas/room";
-import { CreateScheduleItemSchema, ScheduleItemSchema } from "./schemas/schedule-item";
+import { CreateScheduleItemSchema, ScheduleItemSchema, UpdateScheduleItemSchema } from "./schemas/schedule-item";
 import { TeacherSchema } from "./schemas/teacher";
 import { TeachingUnitSchema } from "./schemas/teaching-unit";
 
@@ -12,3 +12,4 @@ export type ITeacher = z.infer<typeof TeacherSchema>;
 export type ITeachingUnit = z.infer<typeof TeachingUnitSchema>;
 export type ICreateScheduleItem = z.infer<typeof CreateScheduleItemSchema>;
 export type ILevelDetails = z.infer<typeof LevelDetailsSchema>;
+export type IUpdateScheduleItem = z.infer<typeof UpdateScheduleItemSchema>;

--- a/src/app/(Main)/EDT/ui/schedule-form.tsx
+++ b/src/app/(Main)/EDT/ui/schedule-form.tsx
@@ -199,8 +199,8 @@ export default function ScheduleForm() {
 
     const handleDelete = () => {
         if (!selectedScheduleItem) return;
-        deleteScheduleItemService(selectedScheduleItem.id).then((deletedScheduleItem) => {
-            removeScheduleItem(deletedScheduleItem.id);
+        deleteScheduleItemService(selectedScheduleItem.id).then((deletedScheduleItemId) => {
+            removeScheduleItem(deletedScheduleItemId);
             form.reset();
             setOpen(false);
         }).catch((error) => {

--- a/src/services/ScheduleItem.ts
+++ b/src/services/ScheduleItem.ts
@@ -3,8 +3,13 @@
 "use server";
 
 import { ScheduleItem, ScheduleItemPost } from "@/Types/ScheduleItem";
-import { createScheduleItem, fetchScheduleItemsForLevel } from "@/api/http/schedule-item";
-import { ICreateScheduleItem } from "@/api/types";
+import {
+    createScheduleItem,
+    deleteScheduleItem,
+    fetchScheduleItemsForLevel,
+    updateScheduleItem
+} from "@/api/http/schedule-item";
+import { ICreateScheduleItem, IUpdateScheduleItem } from "@/api/types";
 import { ScheduleItemMapper } from "@/services/mapper";
 
 export async function getScheduleItems (startTime: Date, endTime: Date): Promise<ScheduleItem[]> {
@@ -21,7 +26,7 @@ export async function addScheduleItemService (scheduleItem: ScheduleItemPost): P
     const requestBody: ICreateScheduleItem = {
         startTime: scheduleItem.startTime,
         endTime: scheduleItem.endTime,
-        groupIds: scheduleItem.GroupIds.map(s => parseInt(s,10)),
+        groupIds: scheduleItem.GroupIds.map(s => parseInt(s, 10)),
         teacherId: scheduleItem.TeacherId,
         teachingUnitId: scheduleItem.TeachingUnitID,
         roomId: scheduleItem.RoomId
@@ -30,12 +35,20 @@ export async function addScheduleItemService (scheduleItem: ScheduleItemPost): P
     return ScheduleItemMapper.fromDto(item);
 }
 
-export async function updateScheduleItemService (id:number,scheduleItem: ScheduleItemPost): Promise<ScheduleItem> {
-    // TODO: Implement update functionality logic
-    throw new Error("Not implemented");
+export async function updateScheduleItemService (id: number, scheduleItem: ScheduleItemPost): Promise<ScheduleItem> {
+    const requestBody: IUpdateScheduleItem = {
+        endTime: scheduleItem.endTime,
+        startTime: scheduleItem.startTime,
+        groupIds: scheduleItem.GroupIds.map(s => parseInt(s, 10)),
+        roomId: scheduleItem.RoomId,
+        teacherId: scheduleItem.TeacherId,
+        teachingUnitId: scheduleItem.TeachingUnitID
+    }
+    const item = await updateScheduleItem(id, requestBody);
+    return ScheduleItemMapper.fromDto(item);
 }
 
-export async function deleteScheduleItemService (id:number): Promise<ScheduleItem> {
-    // TODO: Implement delete functionality logic
-    throw new Error("Not implemented");
+export async function deleteScheduleItemService (id: number): Promise<number> {
+    await deleteScheduleItem(id);
+    return id;
 }


### PR DESCRIPTION
This pull request adds update and delete functionality for schedule items to the API and service layers. It introduces new types and schemas to support these operations, and implements the required logic in both backend and frontend code. The changes also update the form handling to use the new delete service.

**API and Schema Enhancements**
* Added `IUpdateScheduleItem` type and `UpdateScheduleItemSchema` to support updating schedule items. [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR15) [[2]](diffhunk://#diff-2cbe0fc4901eccefb8588b82e08b6d82be7d1ccc8321510502431406ecc430b4R25-R33)
* Added `updateScheduleItem` and `deleteScheduleItem` functions to `src/api/http/schedule-item.ts` for PUT and DELETE HTTP requests.

**Service Layer Updates**
* Implemented `updateScheduleItemService` and `deleteScheduleItemService` in `src/services/ScheduleItem.ts`, including request body mapping and return types.
* Updated imports in `src/services/ScheduleItem.ts` to include new API functions and types.

**Frontend Integration**
* Modified the delete handler in `ScheduleForm` to use the new `deleteScheduleItemService` and correctly remove items by ID.