### PR TITLE
feat: teaching unit service

### DIFF
--- a/src/api/http/teaching-unit.ts
+++ b/src/api/http/teaching-unit.ts
@@ -1,8 +1,22 @@
-import { ITeachingUnit } from "@/api/types";
+import { ICreateTeachingUnitSchema, ITeachingUnit, IUpdateTeachingUnitSchema } from "@/api/types";
 import { http } from "@/api/http/axios";
 import { DTO } from "@/api/schemas";
 
 export async function fetchTeachingUnits (): Promise<ITeachingUnit[]> {
     const {data: responseData} = await http.pub.get("/teachingUnits");
     return DTO.TeachingUnitSchema.array().parse(responseData);
+}
+
+export async function createTeachingUnit (data: ICreateTeachingUnitSchema): Promise<ITeachingUnit> {
+    const {data: responseData} = await http.pub.post("/teachingUnits", data);
+    return DTO.TeachingUnitSchema.parse(responseData);
+}
+
+export async function deleteTeachingUnit (unitId: number) {
+    await http.pub.delete(`/teachingUnits/${unitId}`);
+}
+
+export async function updateTeachingUnit (unitId: number, data: IUpdateTeachingUnitSchema): Promise<ITeachingUnit> {
+    const {data: responseData} = await http.pub.put(`/teachingUnits/${unitId}`, data);
+    return DTO.TeachingUnitSchema.parse(responseData);
 }

--- a/src/api/schemas/teaching-unit.ts
+++ b/src/api/schemas/teaching-unit.ts
@@ -1,9 +1,13 @@
 import z from "zod";
 import { LevelSchema } from "@/api/schemas/level";
 
-export const TeachingUnitSchema = z.object({
-    id: z.number(),
+const BaseTeachingUnitSchema = z.object({
     abbreviation: z.string(),
     name: z.string(),
-    level: LevelSchema,
+    levelId: z.number().nullable()
 });
+export const TeachingUnitSchema = BaseTeachingUnitSchema
+    .omit({levelId: true})
+    .extend({level: LevelSchema.nullable(), id: z.number()});
+export const CreateTeachingUnitSchema = BaseTeachingUnitSchema;
+export const UpdateTeachingUnitSchema = BaseTeachingUnitSchema;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3,7 +3,7 @@ import { GroupSchema, LevelDetailsSchema } from "./schemas/group";
 import { CreateRoomSchema, RoomSchema, UpdateRoomSchema } from "./schemas/room";
 import { CreateScheduleItemSchema, ScheduleItemSchema, UpdateScheduleItemSchema } from "./schemas/schedule-item";
 import { TeacherSchema } from "./schemas/teacher";
-import { TeachingUnitSchema } from "./schemas/teaching-unit";
+import { CreateTeachingUnitSchema, TeachingUnitSchema, UpdateTeachingUnitSchema } from "./schemas/teaching-unit";
 
 export type IGroup = z.infer<typeof GroupSchema>;
 export type IRoom = z.infer<typeof RoomSchema>;
@@ -12,6 +12,8 @@ export type ITeacher = z.infer<typeof TeacherSchema>;
 export type ITeachingUnit = z.infer<typeof TeachingUnitSchema>;
 export type ICreateScheduleItem = z.infer<typeof CreateScheduleItemSchema>;
 export type ILevelDetails = z.infer<typeof LevelDetailsSchema>;
+export type IUpdateTeachingUnitSchema = z.infer<typeof UpdateTeachingUnitSchema>;
+export type ICreateTeachingUnitSchema = z.infer<typeof CreateTeachingUnitSchema>;
 export type ICreateRoom = z.infer<typeof CreateRoomSchema>;
 export type IUpdateRoom = z.infer<typeof UpdateRoomSchema>;
 export type IUpdateScheduleItem = z.infer<typeof UpdateScheduleItemSchema>;

--- a/src/app/(Main)/TeachingUnit/page.tsx
+++ b/src/app/(Main)/TeachingUnit/page.tsx
@@ -46,8 +46,8 @@ export default function Page() {
 
     const handleRemove = (id: number) => {
         RemoveTeachingUnitService(id)
-            .then((removedTeachingUnit) => {
-                removeTeachingUnitInStore(removedTeachingUnit.id);
+            .then((removedTeachingUnitId) => {
+                removeTeachingUnitInStore(removedTeachingUnitId);
                 setIsConfirmationModalOpen(false);
             }).catch((error) => {
             console.error("Failed to remove teaching unit:", error);

--- a/src/services/TeachingUnit.ts
+++ b/src/services/TeachingUnit.ts
@@ -2,26 +2,42 @@
 
 "use server";
 
-import {TeachingUnit, TeachingUnitPost} from "@/Types/TeachingUnit";
-import { fetchTeachingUnits } from "@/api/http/teaching-unit";
+import { TeachingUnit, TeachingUnitPost } from "@/Types/TeachingUnit";
+import {
+    createTeachingUnit,
+    deleteTeachingUnit,
+    fetchTeachingUnits,
+    updateTeachingUnit
+} from "@/api/http/teaching-unit";
 import { TeachingUnitMapper } from "@/services/mapper";
+import { ICreateTeachingUnitSchema, IUpdateTeachingUnitSchema } from "@/api/types";
 
-export async function getTeachingUnits(): Promise<TeachingUnit[]> {
+export async function getTeachingUnits (): Promise<TeachingUnit[]> {
     const teachingUnitsList = await fetchTeachingUnits();
     return teachingUnitsList.map(tu => TeachingUnitMapper.fromDto(tu));
 }
 
-export async function AddTeachingUnitService(data: TeachingUnitPost): Promise<TeachingUnit> {
-    // TODO: implement the service to add a teaching unit
-    throw new Error("Not implemented");
+export async function AddTeachingUnitService (data: TeachingUnitPost): Promise<TeachingUnit> {
+    const requestBody: ICreateTeachingUnitSchema = {
+        name: data.name,
+        abbreviation: data.abr,
+        levelId: data.associatedLevels,
+    };
+    const createdTeachingUnit = await createTeachingUnit(requestBody);
+    return TeachingUnitMapper.fromDto(createdTeachingUnit);
 }
 
-export async function UpdateTeachingUnitService(id: number, data: TeachingUnitPost): Promise<TeachingUnit> {
-    // TODO: implement the service to update a teaching unit
-    throw new Error("Not implemented");
+export async function UpdateTeachingUnitService (id: number, data: TeachingUnitPost): Promise<TeachingUnit> {
+    const requestBody: IUpdateTeachingUnitSchema = {
+        name: data.name,
+        abbreviation: data.abr,
+        levelId: data.associatedLevels,
+    };
+    const updatedTeachingUnit = await updateTeachingUnit(id, requestBody);
+    return TeachingUnitMapper.fromDto(updatedTeachingUnit);
 }
 
-export async function RemoveTeachingUnitService(id: number): Promise<TeachingUnit> {
-    // TODO: implement the service to remove a teaching unit
-    throw new Error("Not implemented");
+export async function RemoveTeachingUnitService (id: number): Promise<number> {
+    await deleteTeachingUnit(id);
+    return id;
 }

--- a/src/services/mapper.ts
+++ b/src/services/mapper.ts
@@ -33,7 +33,7 @@ export const TeachingUnitMapper = {
             id: dto.id,
             abr: dto.abbreviation,
             name: dto.name,
-            associatedLevels: dto.level.id
+            associatedLevels: dto.level?.id
         };
     },
 }

--- a/src/services/mapper.ts
+++ b/src/services/mapper.ts
@@ -33,7 +33,7 @@ export const TeachingUnitMapper = {
             id: dto.id,
             abr: dto.abbreviation,
             name: dto.name,
-            associatedLevels: dto.level?.id
+            associatedLevels: dto.level?.id || null
         };
     },
 }


### PR DESCRIPTION
This pull request implements full CRUD (Create, Read, Update, Delete) operations for teaching units in the API and service layers, updates type definitions and schemas to support these operations, and ensures proper mapping and error handling in related code. The most important changes are grouped below.

### API and Service Layer Enhancements

* Added `createTeachingUnit`, `updateTeachingUnit`, and `deleteTeachingUnit` functions to `src/api/http/teaching-unit.ts` to support creating, updating, and deleting teaching units via HTTP requests.
* Implemented `AddTeachingUnitService`, `UpdateTeachingUnitService`, and `RemoveTeachingUnitService` in `src/services/TeachingUnit.ts` to use the new API functions, replacing previous placeholder implementations. Now, these services handle the full lifecycle of teaching units.

### Schema and Type Updates

* Refactored the teaching unit schemas in `src/api/schemas/teaching-unit.ts` to introduce `BaseTeachingUnitSchema`, and created separate schemas for creating and updating teaching units. The main schema now includes an optional `level` property and an `id`.
* Updated type exports in `src/api/types.ts` to include `ICreateTeachingUnitSchema` and `IUpdateTeachingUnitSchema`, and adjusted imports to use the new schemas. [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feL6-R6) [[2]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR15-R16)

### Mapping and UI Consistency

* Modified the `TeachingUnitMapper` in `src/services/mapper.ts` to safely handle cases where the `level` property might be null, preventing runtime errors.
* Updated the UI removal handler in `src/app/(Main)/TeachingUnit/page.tsx` to expect and use the teaching unit ID returned from the removal service, ensuring correct state updates.