### PR TITLE
feat: integrate backend API into API token management service

### DIFF
--- a/src/api/http/api-key.ts
+++ b/src/api/http/api-key.ts
@@ -1,0 +1,17 @@
+import { http } from "@/api/http/axios";
+import { DTO } from "@/api/schemas";
+import { IApiKeyResponse, IApiKeyResponseWithRawToken, ICreateApiKey } from "@/api/types";
+
+export async function createApiKey (data: ICreateApiKey): Promise<IApiKeyResponseWithRawToken> {
+    const {data: responseData} = await http.pub.post("/api-keys", data);
+    return DTO.ApiKeyResponseWithRawTokenSchema.parse(responseData);
+}
+
+export async function getAllApiKeys (): Promise<IApiKeyResponse[]> {
+    const {data: responseData} = await http.pub.get("/api-keys");
+    return DTO.ApiKeyResponseSchema.array().parse(responseData);
+}
+
+export async function deleteApiKey (id: number): Promise<void> {
+    await http.pub.delete(`/api-keys/${id}`);
+}

--- a/src/api/schemas/api-key.ts
+++ b/src/api/schemas/api-key.ts
@@ -1,0 +1,16 @@
+import z from "zod";
+
+export const CreateApiKeySchema = z.object({
+    name: z.string(),
+});
+
+export const ApiKeyResponseSchema = z.object({
+    id: z.number(),
+    name: z.string(),
+    prefix: z.string(),
+    createdAt: z.string().datetime(),
+});
+
+export const ApiKeyResponseWithRawTokenSchema = ApiKeyResponseSchema.extend({
+    rawToken: z.string(),
+});

--- a/src/api/schemas/index.ts
+++ b/src/api/schemas/index.ts
@@ -6,6 +6,7 @@ import { TeacherSchema } from "./teacher";
 import { TeachingUnitSchema } from "./teaching-unit";
 import { LoginResponseSchema } from "@/api/schemas/auth";
 import { ImportSummarySchema } from "@/api/schemas/import";
+import { ApiKeyResponseSchema, ApiKeyResponseWithRawTokenSchema } from "@/api/schemas/api-key";
 
 export const DTO = {
     CreateScheduleItemSchema,
@@ -19,4 +20,6 @@ export const DTO = {
     BulkScheduleItemCreationResponseSchema,
     LoginResponseSchema,
     ImportSummarySchema,
+    ApiKeyResponseWithRawTokenSchema,
+    ApiKeyResponseSchema
 }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,6 +12,7 @@ import { CreateTeachingUnitSchema, TeachingUnitSchema, UpdateTeachingUnitSchema 
 import { CreateLevelSchema, LevelSchema, UpdateLevelSchema } from "@/api/schemas/level";
 import { ImportSummarySchema } from "@/api/schemas/import";
 import { LoginRequestSchema, LoginResponseSchema, PasswordChangeSchema, UserInfoSchema } from "@/api/schemas/auth";
+import { ApiKeyResponseSchema, ApiKeyResponseWithRawTokenSchema, CreateApiKeySchema } from "@/api/schemas/api-key";
 
 export type IGroup = z.infer<typeof GroupSchema>;
 export type IRoom = z.infer<typeof RoomSchema>;
@@ -49,3 +50,6 @@ export type ILoginResponse = z.infer<typeof LoginResponseSchema>;
 export type ILoginRequest = z.infer<typeof LoginRequestSchema>;
 export type IUserInfo = z.infer<typeof UserInfoSchema>;
 export type IPasswordChange = z.infer<typeof PasswordChangeSchema>;
+export type ICreateApiKey = z.infer<typeof CreateApiKeySchema>;
+export type IApiKeyResponseWithRawToken = z.infer<typeof ApiKeyResponseWithRawTokenSchema>;
+export type IApiKeyResponse = z.infer<typeof ApiKeyResponseSchema>;

--- a/src/app/(Main)/Acces-Token/UI/create-token-dialog.tsx
+++ b/src/app/(Main)/Acces-Token/UI/create-token-dialog.tsx
@@ -47,7 +47,7 @@ export function CreateTokenDialog({ onTokenCreated }: createTokenDialogProps) {
     const onSubmit = async (input: CreateTokenFormValues) => {
         createNewTokens(input.name).then((data)=>{
             const { token, ...tokenData } = data;
-            setGeneratedToken(tokenData.prefix+token);
+            setGeneratedToken(token);
             onTokenCreated(tokenData);
             notifications.success("Token créé", "Votre token d'accès API a été généré avec succès.");
         }).catch(()=>{

--- a/src/services/mapper.ts
+++ b/src/services/mapper.ts
@@ -1,4 +1,5 @@
 import {
+    IApiKeyResponse, IApiKeyResponseWithRawToken,
     ICreateScheduleItem,
     IGroup,
     IImportMapping,
@@ -15,6 +16,7 @@ import { Teacher } from "@/Types/Teacher";
 import { ScheduleItem, ScheduleItemPost } from "@/Types/ScheduleItem";
 import { LevelDTO } from "@/Types/LevelDTO";
 import { ImportMapping } from "@/lib/types";
+import { ApiToken, ApiTokenResponse } from "@/Types/token";
 
 export const LevelMapper = {
     fromDto(dto: ILevel): LevelDTO{
@@ -114,9 +116,32 @@ export const ImportMapper = {
             if (!acc.metadata[sourceFileName]) acc.metadata[sourceFileName] = {};
             acc.metadata[sourceFileName][sub] = {
                 entityType: tableName || "",
-                headersMapping: Object.fromEntries(columnMappings.map(c => [c.fileColumn, c.tableColumn || ""])),
+                headersMapping: Object.fromEntries(columnMappings
+                    .filter(c => !!c)
+                    .map(c => [c.fileColumn, c.tableColumn || ""])
+                ),
             };
             return acc;
         }, {metadata: {}} as IImportMapping);
     }
+}
+
+export const ApiTokenMapper = {
+    fromDto (dto: IApiKeyResponse): ApiToken {
+        return {
+            name: dto.name,
+            id: dto.id + "",
+            prefix: dto.prefix,
+            createdAt: new Date(dto.createdAt),
+        }
+    },
+    fromDtoWithRawToken (dto: IApiKeyResponseWithRawToken): ApiTokenResponse {
+        return {
+            token: dto.rawToken,
+            name: dto.name,
+            id: dto.id + "",
+            prefix: dto.prefix,
+            createdAt: new Date(dto.createdAt)
+        }
+    },
 }

--- a/src/services/token.ts
+++ b/src/services/token.ts
@@ -1,42 +1,19 @@
 "use server";
 
-import {ApiToken, ApiTokenResponse} from "@/Types/token";
-
-const MOCK_TOKENS: ApiToken[] = [
-    { id: "1", name: "Serveur Staging", prefix: "2RK_Api_", createdAt: new Date("2023-10-01") },
-    { id: "2", name: "Intégration Zapier", prefix: "2RK_Api_", createdAt: new Date("2024-01-15") },
-];
-
-const mockCreateTokenService = async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return `${Math.random().toString(36).substr(2, 9)}_${Math.random().toString(36).substr(2, 9)}`;
-};
+import { ApiToken, ApiTokenResponse } from "@/Types/token";
+import { createApiKey, deleteApiKey, getAllApiKeys } from "@/api/http/api-key";
+import { ApiTokenMapper } from "@/services/mapper";
 
 export async function getAllTokens():Promise<ApiToken[]> {
-    //TODO: implement logic
-    return MOCK_TOKENS;
+    const apiKeysList = await getAllApiKeys();
+    return apiKeysList.map(k => ApiTokenMapper.fromDto(k));
 }
 
 export async function createNewTokens(name:string):Promise<ApiTokenResponse> {
-    //TODO: implement logic
-    const token = await mockCreateTokenService();
-    const newToken: ApiTokenResponse = {
-        id: (MOCK_TOKENS.length + 1).toString(),
-        name,
-        prefix: "2rk_api_",
-        createdAt: new Date(),
-        token,
-    };
-    MOCK_TOKENS.unshift(newToken);
-    return newToken;
+    const created = await createApiKey({name});
+    return ApiTokenMapper.fromDtoWithRawToken(created);
 }
 
 export async function deleteToken(tokenId:string) {
-    //TODO: implement logic
-    const index = MOCK_TOKENS.findIndex((token) => token.id === tokenId);
-    if (index !== -1) {
-        MOCK_TOKENS.splice(index, 1);
-    } else {
-        throw new Error("Token not found");
-    }
+    await deleteApiKey(parseInt(tokenId));
 }


### PR DESCRIPTION
This pull request implements full integration of API key management with the backend, replacing the previous mock implementations. The changes introduce new API schemas, types, and HTTP functions for API key operations, update the service and mapping logic to use these, and clean up the codebase by removing mock data and functions.

**API Key Integration and Data Flow**

- Added new HTTP functions for creating, fetching, and deleting API keys in `src/api/http/api-key.ts` using real backend endpoints.
- Introduced Zod schemas for API key creation and response validation in `src/api/schemas/api-key.ts`, and registered them in the DTO export for wider use. [[1]](diffhunk://#diff-29d8d4f24b3e8870c011e071c94c10f5fcfb04f87cbdd08681337c3da8bdb6c4R1-R16) [[2]](diffhunk://#diff-a459b2e36c13e762b4a84e4c5730de872ea861cd68caae91f765a1cc1dbeae83R9) [[3]](diffhunk://#diff-a459b2e36c13e762b4a84e4c5730de872ea861cd68caae91f765a1cc1dbeae83R23-R24)
- Defined new types for API key data structures in `src/api/types.ts` based on the new schemas. [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR15) [[2]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR53-R55)

**Service and Mapping Layer Updates**

- Added `ApiTokenMapper` in `src/services/mapper.ts` to convert API key DTOs into frontend-friendly types, and updated import/export logic accordingly. [[1]](diffhunk://#diff-19591c55d2f0f54469626d0fc6fbd7a43b1efcd79d9475edb12ad54f48a28fb1R2) [[2]](diffhunk://#diff-19591c55d2f0f54469626d0fc6fbd7a43b1efcd79d9475edb12ad54f48a28fb1R19) [[3]](diffhunk://#diff-19591c55d2f0f54469626d0fc6fbd7a43b1efcd79d9475edb12ad54f48a28fb1L117-R147)
- Replaced all mock logic in `src/services/token.ts` with real API calls and mapping, ensuring token creation, fetching, and deletion now interact with the backend.

**UI/API Response Consistency**

- Updated the token creation dialog to use the correct token property (`rawToken`) from the backend response, ensuring the generated token is displayed properly.