### PR TITLE
fix: fix group display in form,

### DIFF
--- a/src/app/(Main)/EDT/ui/EdtEncapsuler.tsx
+++ b/src/app/(Main)/EDT/ui/EdtEncapsuler.tsx
@@ -58,7 +58,7 @@ export default function EdtEncapsuler() {
 					(day, index: number) =>
 						index > 0 && (
 							<div key={day} className="flex border-b-2 relative py-2">
-								<div className="w-20 flex items-center justify-center font-semibold">
+								<div className="w-20 flex items-center justify-start font-semibold">
 									{day}
 								</div>
 								<div className="flex-1 relative">

--- a/src/app/(Main)/EDT/ui/ScheduleItemCard.tsx
+++ b/src/app/(Main)/EDT/ui/ScheduleItemCard.tsx
@@ -1,30 +1,31 @@
-import {ScheduleItem} from "@/Types/ScheduleItem";
-import {getWidthPercentage} from "@/Tools/ScheduleItem";
-import {getColorGroups} from "@/Tools/Color";
+import { ScheduleItem } from "@/Types/ScheduleItem";
+import { getWidthPercentage } from "@/Tools/ScheduleItem";
+import { getColorGroups } from "@/Tools/Color";
 import {
 	useDisplayScheduleItem,
 	useOpenScheduleItemFormStore,
 	useSelectedScheduleItemStore
 } from "@/Stores/ScheduleItem";
 
-
 interface Props {
 	scheduleItem: ScheduleItem;
 	left: number;
 }
 
-export default function ScheduleItemCard({ scheduleItem,left }: Props) {
-	const displayMode = useDisplayScheduleItem((s)=> s.displayMode)
+export default function ScheduleItemCard({ scheduleItem, left }: Props) {
+	const displayMode = useDisplayScheduleItem((s) => s.displayMode);
 	const setSelectedScheduleItem = useSelectedScheduleItemStore((s) => s.setSelectedScheduleItem);
 	const setOpen = useOpenScheduleItemFormStore((s) => s.setOpen);
+
 	const width = getWidthPercentage(scheduleItem.startTime, scheduleItem.endTime);
+
 	const UpdateScheduleItem = () => {
 		setSelectedScheduleItem(scheduleItem);
 		setOpen(true);
-	}
+	};
 
-	const getDisplayModeLabel = () =>{
-		switch(displayMode){
+	const getDisplayModeLabel = () => {
+		switch (displayMode) {
 			case 'Student':
 				return scheduleItem.Room ? `${scheduleItem.Room.abr} - ${scheduleItem.Teacher.abr}` : `${scheduleItem.Teacher.abr}`;
 			case 'Teacher':
@@ -34,29 +35,44 @@ export default function ScheduleItemCard({ scheduleItem,left }: Props) {
 			default:
 				return '';
 		}
-	}
+	};
+	const formattedStartTime = scheduleItem.startTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+	const formattedEndTime = scheduleItem.endTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+	const groupsString = scheduleItem.Groups.map((g) => g.type + " " + g.classe + " " + g.name).join(", ");
 
 	return (
 		<div
-			className={`border p-1 pb-2 rounded shadow-sm overflow-hidden cursor-pointer ${getColorGroups(scheduleItem.Groups)}`}
-
+			onClick={UpdateScheduleItem}
+			className={`
+				group relative flex flex-col p-2 rounded-md shadow-sm border border-black/10
+				cursor-pointer overflow-hidden transition-all duration-200 ease-in-out
+				hover:shadow-md hover:scale-[1.02] hover:z-10 hover:brightness-105
+				${getColorGroups(scheduleItem.Groups)}
+			`}
 			style={{
 				flexBasis: `${width}%`,
 				marginLeft: `${left}%`,
 				flexGrow: 0,
 				flexShrink: 0,
 			}}
+			title="Cliquez pour modifier"
 		>
-			<div onClick={UpdateScheduleItem} className="text-[11px] whitespace-normal leading-tight">
-				<span>{scheduleItem.TeachingUnit.abr}</span>
-				<br/>
-				{getDisplayModeLabel()}
-				<br />
-				{scheduleItem.startTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false })} -&nbsp;
-				{scheduleItem.endTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit',hour12: false })}
-				<br />
-				<span>Groupes :</span>&nbsp;
-				{scheduleItem.Groups.map((g) => g.type + g.classe + g.name).join(", ")}
+			<div className="flex justify-between items-start gap-2 mb-1">
+				<span className="font-bold text-[12px] leading-tight truncate">
+					{scheduleItem.TeachingUnit.abr}
+				</span>
+				<span className="font-semibold text-[11px] opacity-80 whitespace-nowrap bg-black/5 px-1 rounded">
+					{getDisplayModeLabel()}
+				</span>
+			</div>
+			<div className="flex items-center text-[11px] font-medium opacity-90 mb-1">
+				<svg className="w-3 h-3 mr-1 opacity-70" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+				</svg>
+				{formattedStartTime} - {formattedEndTime}
+			</div>
+			<div className="mt-auto pt-1 text-[10px] border-t border-black/10 opacity-80 truncate">
+				<span className="font-semibold">Grp :</span> {groupsString}
 			</div>
 		</div>
 	);

--- a/src/app/(Main)/EDT/ui/schedule-form.tsx
+++ b/src/app/(Main)/EDT/ui/schedule-form.tsx
@@ -526,9 +526,9 @@ export default function ScheduleForm({
                                                                                     className="flex items-center justify-between">
                                                                                     <div>
                                                                                         <span
-                                                                                            className="font-medium">{group.name}</span>
+                                                                                            className="font-medium">{group.type+" "+group.name}</span>
                                                                                         <span
-                                                                                            className="text-muted-foreground ml-2">({group.name})</span>
+                                                                                            className="text-muted-foreground ml-2">({group.classe})</span>
                                                                                     </div>
                                                                                     <span
                                                                                         className="text-sm text-muted-foreground">{group.size} étudiants</span>


### PR DESCRIPTION
This pull request focuses on improving the UI and readability of schedule-related components in the EDT (Emploi du Temps) feature. The main changes enhance the visual presentation of schedule items, improve group labeling, and refine some layout details for a better user experience.

**UI and Layout Improvements:**

* [`ScheduleItemCard.tsx`](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L37-R75): Redesigned the schedule item card for better readability and interactivity. The card now uses a cleaner layout with clearer typography, hover effects, a clickable area to open the edit form, and improved display of teaching unit abbreviations, times, and group information.
* [`EdtEncapsuler.tsx`](diffhunk://#diff-acee9ad0e6b2275dd02c3e5ae860e4b7e0aa88617323bfad63cdec53e252c68aL61-R61): Adjusted the alignment of day labels in the schedule view to left-align instead of center, making the timetable easier to scan.

**Group Labeling Consistency:**

* [`ScheduleItemCard.tsx`](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L37-R75): Standardized the formatting of group names by including group type, class, and name, separated by spaces and commas for clarity.
* [`schedule-form.tsx`](diffhunk://#diff-443e0b54cfecbaee3b646455964b3b0bdcd2fbdbd100cb55b62c2498818692fcL529-R531): Updated group labels in the schedule form to display both the group type and class, making group identification more consistent and informative throughout the UI.

**Code Quality and Readability:**

* [`ScheduleItemCard.tsx`](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L10-R25): Improved code formatting and variable naming for better maintainability, including extracting formatted time and group strings and cleaning up event handler definitions.