### PR TITLE
fix: fix overflow bug

### DIFF
--- a/src/app/(Main)/EDT/ui/ScheduleDisplay.tsx
+++ b/src/app/(Main)/EDT/ui/ScheduleDisplay.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {useDisplayScheduleItem} from "@/Stores/ScheduleItem";
 import {calculateRowAssignments, getDayOffsetPercentage} from "@/Tools/ScheduleItem";
 import ScheduleItemCard from "@/app/(Main)/EDT/ui/ScheduleItemCard";
@@ -14,22 +15,49 @@ export default function ScheduleDisplay({jourIndex}: ScheduleDisplayProps) {
 
     const rows = calculateRowAssignments(joursHoraires);
 
+    // Track heights of cards in each row: key is `${rowIndex}-${cardIndex}`
+    const [cardHeights, setCardHeights] = useState<Record<string, number>>({});
+
+    const handleHeightChange = (rowIndex: number, cardIndex: number, height: number) => {
+        const key = `${rowIndex}-${cardIndex}`;
+        setCardHeights((prev) => {
+            if (prev[key] === height) return prev;
+            return {
+                ...prev,
+                [key]: height,
+            };
+        });
+    };
+
+    const getRowHeight = (rowIndex: number) => {
+        const heights = Object.entries(cardHeights)
+            .filter(([key]) => key.startsWith(`${rowIndex}-`))
+            .map(([_, val]) => val);
+        return heights.length > 0 ? Math.max(...heights, 105) : 105;
+    };
+
     return (
         <div className="flex flex-col w-full gap-2">
             {rows.map((row, rowIndex) => {
+                const rowHeight = getRowHeight(rowIndex);
                 return (
-                    <div key={rowIndex} className="relative w-full h-[105px]">
-                        {row.map((scheduleItem, index) => (
+                    <div 
+                        key={rowIndex} 
+                        className="relative w-full transition-all duration-200 ease-in-out"
+                        style={{ height: `${rowHeight}px` }}
+                    >
+                        {row.map((scheduleItem, cardIndex) => (
                             <ScheduleItemCard
-                                key={index}
+                                key={cardIndex}
                                 scheduleItem={scheduleItem}
                                 left={getDayOffsetPercentage(scheduleItem.startTime)}
+                                cardIndex={cardIndex}
+                                onHeightChange={(cIdx, h) => handleHeightChange(rowIndex, cIdx, h)}
                             />
                         ))}
                     </div>
                 );
-            }
-            )}
+            })}
         </div>
     );
 }

--- a/src/app/(Main)/EDT/ui/ScheduleItemCard.tsx
+++ b/src/app/(Main)/EDT/ui/ScheduleItemCard.tsx
@@ -3,6 +3,7 @@ import { getWidthPercentage } from "@/Tools/ScheduleItem";
 import { generateColorFromStrings } from "@/Tools/Color";
 import { Button } from "@/components/ui/button";
 import { Copy, Clock, MapPin, User, Users, GraduationCap } from "lucide-react";
+import { useRef, useEffect } from "react";
 import type { MouseEvent } from "react";
 import {
 	useCopiedScheduleItemStore,
@@ -14,13 +15,46 @@ import {
 interface Props {
 	scheduleItem: ScheduleItem;
 	left: number;
+	cardIndex?: number;
+	onHeightChange?: (cardIndex: number, height: number) => void;
 }
 
-export default function ScheduleItemCard({ scheduleItem, left }: Props) {
+export default function ScheduleItemCard({ scheduleItem, left, cardIndex, onHeightChange }: Props) {
 	const displayMode = useDisplayScheduleItem((s) => s.displayMode);
 	const setSelectedScheduleItem = useSelectedScheduleItemStore((s) => s.setSelectedScheduleItem);
 	const setCopiedScheduleItem = useCopiedScheduleItemStore((s) => s.setCopiedScheduleItem);
 	const setOpen = useOpenScheduleItemFormStore((s) => s.setOpen);
+
+	const topSectionRef = useRef<HTMLDivElement>(null);
+	const bottomSectionRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!topSectionRef.current || !bottomSectionRef.current || !onHeightChange || cardIndex === undefined) return;
+
+		const measure = () => {
+			const topHeight = topSectionRef.current?.offsetHeight || 0;
+			const bottomHeight = bottomSectionRef.current?.offsetHeight || 0;
+			// padding: p-2.5 is 10px top/bottom (20px total)
+			// border: 1px top/bottom (2px total)
+			// spacing between sections (12px)
+			const contentHeight = topHeight + bottomHeight + 20 + 2 + 12;
+			const finalHeight = Math.max(contentHeight, 105);
+			onHeightChange(cardIndex, finalHeight);
+		};
+
+		measure();
+
+		const resizeObserver = new ResizeObserver(() => {
+			measure();
+		});
+
+		resizeObserver.observe(topSectionRef.current);
+		resizeObserver.observe(bottomSectionRef.current);
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, [onHeightChange, cardIndex, displayMode, scheduleItem.Groups]);
 
 	const width = getWidthPercentage(scheduleItem.startTime, scheduleItem.endTime);
 
@@ -60,7 +94,7 @@ export default function ScheduleItemCard({ scheduleItem, left }: Props) {
 	return (
 		<div
 			onClick={UpdateScheduleItem}
-			className="group absolute top-0 flex flex-col p-2.5 rounded-xl border transition-all duration-200 ease-in-out cursor-pointer hover:shadow-md hover:z-10 select-none overflow-hidden h-[105px]"
+			className="group absolute top-0 flex flex-col p-2.5 rounded-xl border transition-all duration-200 ease-in-out cursor-pointer hover:shadow-md hover:z-10 select-none overflow-hidden h-full"
 			style={{
 				left: `${left}%`,
 				width: `${width}%`,
@@ -80,7 +114,7 @@ export default function ScheduleItemCard({ scheduleItem, left }: Props) {
 
 			<div className="flex flex-col justify-between h-full w-full text-slate-700 dark:text-slate-200 text-left">
 
-				<div className="space-y-1">
+				<div ref={topSectionRef} className="space-y-1">
 					<div className="pr-5">
 						<h4 className="font-bold text-[13px] tracking-tight text-slate-900 dark:text-white line-clamp-1 leading-none">
 							{scheduleItem.TeachingUnit.abr}
@@ -95,19 +129,19 @@ export default function ScheduleItemCard({ scheduleItem, left }: Props) {
 					</div>
 				</div>
 
-				<div className="space-y-1.5">
+				<div ref={bottomSectionRef} className="space-y-1.5">
 					<div className="text-[11px] font-bold text-slate-700 dark:text-slate-300 flex items-center gap-1 leading-none">
 						<Clock className="h-3 w-3 text-slate-500" />
 						<span>{formattedStartTime} - {formattedEndTime}</span>
 					</div>
 
-					<div className="flex items-center gap-1 border-t border-slate-200/60 dark:border-slate-700/60 pt-1.5 overflow-hidden">
-						<GraduationCap className="h-3 w-3 text-slate-400 flex-shrink-0" />
-						<div className="flex gap-1 overflow-hidden truncate mask-linear-gradient w-full">
+					<div className="flex items-start gap-1 border-t border-slate-200/60 dark:border-slate-700/60 pt-1.5">
+						<GraduationCap className="h-3 w-3 text-slate-400 flex-shrink-0 mt-0.5" />
+						<div className="flex flex-wrap gap-1 w-full">
 							{groupsArray.map((group, index) => (
 								<span
 									key={index}
-									className="text-[9px] font-bold tracking-wide uppercase px-1 py-0.5 bg-slate-200/70 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded flex-shrink-0"
+									className="text-[9px] font-bold tracking-wide uppercase px-1 py-0.5 bg-slate-200/70 dark:bg-slate-800 text-slate-800 dark:text-slate-200 rounded"
 								>
                             {group}
                          </span>


### PR DESCRIPTION
This pull request improves the dynamic layout of the schedule display by making each row automatically adjust its height based on the tallest card it contains. This ensures that schedule items with more content are fully visible and prevents overlap or clipping. The main changes involve tracking the height of each `ScheduleItemCard` and updating the row heights accordingly.

**Dynamic row and card sizing:**

* [`ScheduleDisplay.tsx`](diffhunk://#diff-6ab427ec1f55d2ed94d3c94ad282d936e3fe6760d7594aee759375c978d30f21R18-R60): Added logic to track the heights of all schedule cards within each row and dynamically set the row height to fit the tallest card. This uses a `useState` hook to store card heights and a function to compute each row's height.
* [`ScheduleItemCard.tsx`](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9R18-R58): Each card now measures its own height using `useRef` and `ResizeObserver`, and reports changes to its parent via a new `onHeightChange` prop. The card now fills the row height (`h-full`), instead of being fixed at 105px. [[1]](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9R18-R58) [[2]](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L63-R97)

**Card content and structure improvements:**

* [`ScheduleItemCard.tsx`](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L83-R117): The card's top and bottom sections are now referenced for precise height measurement. The group tags section was updated to wrap content onto multiple lines if needed, improving readability for items with many groups. [[1]](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L83-R117) [[2]](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9L98-R144)

**Other improvements:**

* Updated imports to include necessary React hooks and types for the new features. [[1]](diffhunk://#diff-6ab427ec1f55d2ed94d3c94ad282d936e3fe6760d7594aee759375c978d30f21R1) [[2]](diffhunk://#diff-569121718994c70ae32bed86b175d1298b6d5d8dc0e1bb96c39b62316bf38ac9R6)

These changes collectively make the schedule display more robust, visually consistent, and user-friendly, especially when schedule items vary in content length.