### PR TITLE
Fix printing overflow bug definitely

### DIFF
--- a/src/app/(Main)/EDT/ui/EdtEncapsuler.tsx
+++ b/src/app/(Main)/EDT/ui/EdtEncapsuler.tsx
@@ -45,8 +45,8 @@ export const hours = [
 export default function EdtEncapsuler() {
 
 	return (
-		<div className="border rounded-xl overflow-x-auto bg-card/20 backdrop-blur-sm shadow-sm scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent">
-			<div className="relative min-w-[900px]">
+		<div className="border rounded-xl overflow-x-auto bg-card/20 backdrop-blur-sm shadow-sm scrollbar-thin scrollbar-thumb-muted scrollbar-track-transparent edt-print-root">
+			<div className="relative min-w-[900px] edt-print-inner">
 				{/* Timeline Header */}
 				<div className="flex border-b h-10 items-center bg-muted/30">
 					<div className="w-24 flex-shrink-0 border-r border-muted h-full"></div>
@@ -63,7 +63,7 @@ export default function EdtEncapsuler() {
 						index > 0 && (
 							<div
 								key={day}
-								className="flex border-b relative hover:bg-muted/5 transition-colors"
+								className="flex border-b relative hover:bg-muted/5 transition-colors edt-day-row"
 							>
 								{/* Day Header Column */}
 								<div className="w-24 flex-shrink-0 flex flex-col items-center justify-center font-bold border-r border-muted bg-muted/15 text-muted-foreground select-none py-4 text-center">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,5 @@
+@import "./print.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/src/app/print.css
+++ b/src/app/print.css
@@ -1,0 +1,23 @@
+/* print.css — import this globally, only applies during print */
+@media print {
+  .edt-print-root,
+  .edt-print-root * {
+    overflow: visible !important;
+  }
+
+  .edt-print-root {
+    min-width: 0 !important;
+    width: 100% !important;
+  }
+
+  .edt-print-inner {
+    min-width: 0 !important;
+    width: 100% !important;
+  }
+
+  /* Each day row must never be split across pages */
+  .edt-day-row {
+    break-inside: avoid;
+    page-break-inside: avoid; /* Firefox still wants the old prop */
+  }
+}


### PR DESCRIPTION
Fixes the overflow issues when exporting a schedule to PDF on my desktop browser (FireFox) and on my mobile browser (Google Chrome)